### PR TITLE
Install docker on performance-test instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ The environment variables names are *SSH_KEY_NAME* and *DO_API_TOKEN*
 SSH_KEY_NAME=<do_ssh_key_name> DO_API_TOKEN=<api_token> ansible-playbook playbooks/create_servers.yml
 ```
 
- **Running the above command creates a new host file, and it also changes the ansible config file to point to a new host file.**
-
- **Running this command again fails as the host file will have been changed.**
-
- **To run it again successfully change the *inventory* variable value to *inventory/old.**
+ **Running the above command creates a new host file, and it also changes the ansible config file to point to a new host file.**  
+ **Running this command again fails as the host file will have been changed.**  
+ **To run it again successfully change the *inventory* variable value to *inventory/old.**  
 
 
 ## 3. Initial setup for remote servers

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ The environment variables names are *SSH_KEY_NAME* and *DO_API_TOKEN*
 SSH_KEY_NAME=<do_ssh_key_name> DO_API_TOKEN=<api_token> ansible-playbook playbooks/create_servers.yml
 ```
 
- **Running the above command creates a new host file, and it also changes the ansible config file to point to a new host file.**  
- **Running this command again fails as the host file will have been changed.**  
- **To run it again successfully change the *inventory* variable value to *inventory/old.**  
+ **Running the above command creates a new host file, and it also changes the ansible config file to point to a new host file.  
+ Running this command again fails as the host file will have been changed.  
+ To run it again successfully change the *inventory* variable value to *inventory/old.**  
 
 
 ## 3. Initial setup for remote servers

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ The environment variables names are *SSH_KEY_NAME* and *DO_API_TOKEN*
 SSH_KEY_NAME=<do_ssh_key_name> DO_API_TOKEN=<api_token> ansible-playbook playbooks/create_servers.yml
 ```
 
- *Running the above command creates a new host file, and it also changes the ansible config file to point to a new host file.
+ _Running the above command creates a new host file, and it also changes the ansible config file to point to a new host file.
  Running this command again fails as the host file will have been changed.
- To run it again successfully change the *inventory* variable value to *inventory/old.*  
+ To run it again successfully change the *inventory* variable value to *inventory/old._  
 
 
 ## 3. Initial setup for remote servers

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Each of these playbooks will start the specified test as a detached process in a
 The results can be seen by looking at the logs of the containers at this point.
 
 
-## 7. Destroying the servers
+## 7. Destroy the servers
 
 The server provisioning playbook would have produced an `inventory` file containing the ip addresses and droplet names of the
 provisioned servers. This file will be used to determine which droplets need to be destroyed.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ ansible-playbook playbooks/initial-setup.yml
 To deploy the services first setup the servers file and then run:
 
 ```sh
-ansible-playbook --skip-tags configure playbooks/deploy.yml
+ansible-playbook --skip-tags configuration playbooks/deploy.yml
 ```
 
 The MongoDB replica set will need to be initiated once the services have been deployed. 
@@ -53,7 +53,7 @@ This can be done by following the steps found at https://docs.mongodb.com/manual
 After the services have been deployed and the replica set has been initiated they can be configured with:
 
 ```sh
-ansible-playbook --tags configure playbooks/deploy.yml
+ansible-playbook --tags configuration playbooks/deploy.yml
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -38,17 +38,20 @@ ansible-playbook playbooks/initial-setup.yml
 
 ## 4. Deploy the services
 
+### a. Deploy Docker images to VMs
+
 To deploy the services first setup the servers file and then run:
 
 ```sh
 ansible-playbook --skip-tags configuration playbooks/deploy.yml
 ```
 
+### b. Manually configure MongoDB replicaset
+
 The MongoDB replica set will need to be initiated once the services have been deployed. 
 This can be done by following the steps found at https://docs.mongodb.com/manual/tutorial/deploy-replica-set/#initiate-the-replica-set.
 
-
-## 5. Configure the services
+### c. Configure the services
 
 After the services have been deployed and the replica set has been initiated they can be configured with:
 
@@ -57,7 +60,7 @@ ansible-playbook --tags configuration playbooks/deploy.yml
 ```
 
 
-## 6. Execute the tests
+## 5. Execute the tests
 
 The tests can be executed by running one of:
 
@@ -76,6 +79,22 @@ ansible-playbook playbooks/execute_http_volume_test.yml
 Each of these playbooks will start the specified test as a detached process in a Docker container. 
 The results can be seen by looking at the logs of the containers at this point.
 
+
+## 6. Collect statistics
+
+Collect test output from Docker logs on the performance test machine
+
+```sh
+docker logs openhim-http-stress
+```
+
+```sh
+docker logs openhim-http-volume
+```
+
+```sh
+docker logs openhim-http-load
+```
 
 ## 7. Destroy the servers
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ SSH_KEY_NAME=<do_ssh_key_name> DO_API_TOKEN=<api_token> ansible-playbook playboo
 
 ## 3. Initial setup for remote servers
 
-`python` and `pip` must be installed on the host machines in order for Ansible modules to run on remote targets. 
+`python` (version 2.x) and `pip` must be installed on the host machines in order for Ansible modules to run on remote targets. 
 On Ubuntu this can be done with:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ The environment variables names are *SSH_KEY_NAME* and *DO_API_TOKEN*
 SSH_KEY_NAME=<do_ssh_key_name> DO_API_TOKEN=<api_token> ansible-playbook playbooks/create_servers.yml
 ```
 
- **Running the above command creates a new host file, and it also changes the ansible config file to point to a new host file.  
- Running this command again fails as the host file will have been changed.  
- To run it again successfully change the *inventory* variable value to *inventory/old.**  
+ *Running the above command creates a new host file, and it also changes the ansible config file to point to a new host file.
+ Running this command again fails as the host file will have been changed.
+ To run it again successfully change the *inventory* variable value to *inventory/old.*  
 
 
 ## 3. Initial setup for remote servers

--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@ These tests run on virtual hardware hosted on DigitalOcean and executed using An
 
 - Install the `python` version 2.x package, if not already installed
 - Install the python package manager `pip`
-- Install the Digital Ocean plugin for ansible, `dopy`. Version >= 0.32
-- Generate your api access token on digital ocean. Instructions on how to generate a token can be found [here](https://www.digitalocean.com/docs/api/create-personal-access-token/)
-- Generate an SSH key and add it to DigitalOcean. Note the SSH key name, which can be passed in on the command line or exported as an environment variable
+- Install the DigitalOcean plugin for ansible, `dopy`. Version >= 0.32
+- Generate your API access token on DigitalOcean. Instructions on how to generate a token can be found [here](https://www.digitalocean.com/docs/api/create-personal-access-token/)
+- Generate an SSH key and add it to DigitalOcean, under the *Security* menu on the Do website. The SSH key name used here must match the a named key in the test executor's `.ssh` directory. The key name can be passed in on the command line to the *create_servers* playbook or exported as an environment variable
 
 
 ## 2. Provision servers
 
-Run the ansible command in the `openhim-performance` directory, passing the api access token and the ssh key name as environment variables. 
-The environment variables are named *SSH_KEY_NAME* and *DO_API_TOKEN*.
+Run the ansible command in the `openhim-performance` directory, passing the API access token (named *DO_API_TOKEN*) and the ssh key name (named *SSH_KEY_NAME*) as environment variables. 
 
 ```sh
 SSH_KEY_NAME=<do_ssh_key_name> DO_API_TOKEN=<api_token> ansible-playbook playbooks/create_servers.yml

--- a/README.md
+++ b/README.md
@@ -1,21 +1,33 @@
 # Openhim Load Tests
 
-## Server Setup
-This perfomance test uses servers that are hosted on Digital Ocean. These have to be setup.
+These performance tests use virtual hardware hosted on DigitalOcean.
+ 
 
-### Steps to follow
+
+## Controller (local) machine requirements
+
 - Install the python package manager, 'pip'
 - Install the Digital Ocean plugin for ansible, 'dopy'. Version >= 0.32
 - Generate your api access token on digital ocean. Instructions on how to generate a token can be found [here](https://www.digitalocean.com/docs/api/create-personal-access-token/)
 - Generate an ssh key and add it to digital ocean. Note the ssh key name (shall be passed in as an environment variable)
-- Run the ansible command in the root directory, and pass the api access token and the ssh key name as environment variables. The environment variables names are *SSH_KEY_NAME* and *DO_API_TOKEN*
 
- example command: *SSH_KEY_NAME=<name> DO_API_TOKEN=<token> ansible-playbook ./playbooks/create_servers.yml*
+
+## Provision servers
+
+Run the ansible command in the root directory, and pass the api access token and the ssh key name as environment variables. 
+The environment variables names are *SSH_KEY_NAME* and *DO_API_TOKEN*
+
+```sh
+SSH_KEY_NAME=<do_ssh_key_name> DO_API_TOKEN=<api_token> ansible-playbook playbooks/create_servers.yml
+```
 
  **Running the above command creates a new host file, and it also changes the ansible config file to point to a new host file**
  **Running this command again fails as the host file will have been changed. To run it again successfully change the *inventory* variable value to *inventory/old***
 
-- Python must be installed on the host machines before Ansible can run. On Ubuntu this can be done with:
+
+## Initial setup for remote servers
+
+`python` and `pip` must be installed on the host machines in order for Ansible modules to run on remote targets. On Ubuntu this can be done with:
 
 ```sh
 ansible-playbook playbooks/initial-setup.yml
@@ -32,6 +44,7 @@ ansible-playbook --skip-tags configure playbooks/deploy.yml
 
 The MongoDB replica set will need to be initiated once the services have been deployed. This can be done by following the steps found at https://docs.mongodb.com/manual/tutorial/deploy-replica-set/#initiate-the-replica-set.
 
+
 ## Configure the services
 
 After the services have been deployed and the replica set has been initiated they can be configured with:
@@ -39,6 +52,7 @@ After the services have been deployed and the replica set has been initiated the
 ```sh
 ansible-playbook --tags configure playbooks/deploy.yml
 ```
+
 
 ## Execute the tests
 
@@ -57,6 +71,7 @@ ansible-playbook playbooks/execute_http_volume_test.yml
 ```
 
 Each of these playbooks will start the specified test as a detached process in a Docker container. The results can be seen by looking at the logs of the containers at this point.
+
 
 ## Destroying the servers
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ These performance tests use virtual hardware hosted on DigitalOcean.
  
 
 
-## Controller (local) machine requirements
+## 1. Controller (local) machine requirements
 
 - Install the python package manager, 'pip'
 - Install the Digital Ocean plugin for ansible, 'dopy'. Version >= 0.32
@@ -12,7 +12,7 @@ These performance tests use virtual hardware hosted on DigitalOcean.
 - Generate an ssh key and add it to digital ocean. Note the ssh key name (shall be passed in as an environment variable)
 
 
-## Provision servers
+## 2. Provision servers
 
 Run the ansible command in the root directory, and pass the api access token and the ssh key name as environment variables. 
 The environment variables names are *SSH_KEY_NAME* and *DO_API_TOKEN*
@@ -21,20 +21,24 @@ The environment variables names are *SSH_KEY_NAME* and *DO_API_TOKEN*
 SSH_KEY_NAME=<do_ssh_key_name> DO_API_TOKEN=<api_token> ansible-playbook playbooks/create_servers.yml
 ```
 
- **Running the above command creates a new host file, and it also changes the ansible config file to point to a new host file**
- **Running this command again fails as the host file will have been changed. To run it again successfully change the *inventory* variable value to *inventory/old***
+ **Running the above command creates a new host file, and it also changes the ansible config file to point to a new host file.**
+
+ **Running this command again fails as the host file will have been changed.**
+
+ **To run it again successfully change the *inventory* variable value to *inventory/old.**
 
 
-## Initial setup for remote servers
+## 3. Initial setup for remote servers
 
-`python` and `pip` must be installed on the host machines in order for Ansible modules to run on remote targets. On Ubuntu this can be done with:
+`python` and `pip` must be installed on the host machines in order for Ansible modules to run on remote targets. 
+On Ubuntu this can be done with:
 
 ```sh
 ansible-playbook playbooks/initial-setup.yml
 ```
 
 
-## Deploy the services
+## 4. Deploy the services
 
 To deploy the services first setup the servers file and then run:
 
@@ -42,10 +46,11 @@ To deploy the services first setup the servers file and then run:
 ansible-playbook --skip-tags configure playbooks/deploy.yml
 ```
 
-The MongoDB replica set will need to be initiated once the services have been deployed. This can be done by following the steps found at https://docs.mongodb.com/manual/tutorial/deploy-replica-set/#initiate-the-replica-set.
+The MongoDB replica set will need to be initiated once the services have been deployed. 
+This can be done by following the steps found at https://docs.mongodb.com/manual/tutorial/deploy-replica-set/#initiate-the-replica-set.
 
 
-## Configure the services
+## 5. Configure the services
 
 After the services have been deployed and the replica set has been initiated they can be configured with:
 
@@ -54,7 +59,7 @@ ansible-playbook --tags configure playbooks/deploy.yml
 ```
 
 
-## Execute the tests
+## 6. Execute the tests
 
 The tests can be executed by running one of:
 
@@ -70,10 +75,11 @@ ansible-playbook playbooks/execute_http_stress_test.yml
 ansible-playbook playbooks/execute_http_volume_test.yml
 ```
 
-Each of these playbooks will start the specified test as a detached process in a Docker container. The results can be seen by looking at the logs of the containers at this point.
+Each of these playbooks will start the specified test as a detached process in a Docker container. 
+The results can be seen by looking at the logs of the containers at this point.
 
 
-## Destroying the servers
+## 7. Destroying the servers
 
 The server provisioning playbook would have produced an `inventory` file containing the ip addresses and droplet names of the
 provisioned servers. This file will be used to determine which droplets need to be destroyed.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ These tests run on virtual hardware hosted on DigitalOcean and executed using An
 - Install the python package manager `pip`
 - Install the DigitalOcean plugin for ansible, `dopy`. Version >= 0.32
 - Generate your API access token on DigitalOcean. Instructions on how to generate a token can be found [here](https://www.digitalocean.com/docs/api/create-personal-access-token/)
-- Generate an SSH key and add it to DigitalOcean, under the *Security* menu on the Do website. The SSH key name used here must match the a named key in the test executor's `.ssh` directory. The key name can be passed in on the command line to the *create_servers* playbook or exported as an environment variable
+- Generate an SSH key and add it to DigitalOcean, under the *Security* menu on the DO website. The SSH key name used here must match a named key file in the test executor's `.ssh` directory. The key name can be passed in on the command line to the *create_servers* playbook or exported as an environment variable
 
 
 ## 2. Provision servers
@@ -28,7 +28,7 @@ SSH_KEY_NAME=<do_ssh_key_name> DO_API_TOKEN=<api_token> ansible-playbook playboo
 
 ## 3. Initial setup for remote servers
 
-`python` (version 2.x) and `pip` must be installed on the host machines in order for Ansible modules to run on remote targets. 
+`python` (version 2.x) and `pip` must be installed on the remote hosts in order for Ansible modules to run on those targets. 
 On Ubuntu this can be done with:
 
 ```sh

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -12,4 +12,5 @@
     - mediator
 - hosts: perf
   roles:
+    - docker
     - k6

--- a/roles/appServers/vars/main.yml
+++ b/roles/appServers/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 appInstances:
   - name: app-instance
-size_id: 512mb
+size_id: 1gb
 image_ID: ubuntu-18-04-x64

--- a/roles/dbServers/vars/main.yml
+++ b/roles/dbServers/vars/main.yml
@@ -1,7 +1,5 @@
 ---
 mongoInstances:
   - name: mongo-instance-1
-  - name: mongo-instance-2
-  - name: mongo-instance-3
-size_id: 512mb
+size_id: 1gb
 image_ID: ubuntu-18-04-x64

--- a/roles/mediatorServers/vars/main.yml
+++ b/roles/mediatorServers/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 mediatorInstances:
   - name: mediator-instance
-size_id: 512mb
+size_id: 1gb
 image_ID: ubuntu-18-04-x64

--- a/roles/perfomanceTestServer/vars/main.yml
+++ b/roles/perfomanceTestServer/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 testingInstances:
   - name: testing-instance
-size_id: 1gb
+size_id: 2gb
 image_ID: ubuntu-18-04-x64

--- a/roles/perfomanceTestServer/vars/main.yml
+++ b/roles/perfomanceTestServer/vars/main.yml
@@ -1,5 +1,5 @@
 ---
 testingInstances:
   - name: testing-instance
-size_id: 512mb
+size_id: 1gb
 image_ID: ubuntu-18-04-x64


### PR DESCRIPTION
Prior to this change, docker was not installed, causing the tests
to not run

This change adds a call to the docker-installation role on the host

OHM-758 OHM-689